### PR TITLE
RPi-#95. LEDPlayer frame less than 2 error

### DIFF
--- a/controller/src/ledplayer.cpp
+++ b/controller/src/ledplayer.cpp
@@ -27,6 +27,16 @@ LEDPlayer::Frame& LEDPlayer::Frame::operator=(const LEDPlayer::Frame& f) {
 }
 
 void LEDPlayer::load(const json& pl) {
+    if (pl.size() == 0){
+        Frame frame;
+        frame.start = 0;
+        frame.fade = false;
+        for (int i = 0; i < len; ++i)
+            frame.status.push_back(LEDStatus(0, 0));
+
+        playList.push_back(frame);
+        return;
+    }
     playList.reserve(pl.size());
     for (auto& f : pl) {
         Frame frame(f["start"], f["fade"], f["status"]);

--- a/controller/src/rpiMgr.cpp
+++ b/controller/src/rpiMgr.cpp
@@ -212,8 +212,6 @@ void RPiMgr::lightLEDStatus(const LEDPlayer::Frame& frame, const int& channelId)
         colorCode2RGB(frame.status[i].colorCode, R, G, B);
         LEDrgba_to_rgb(LEDBuf[channelId], i, R, G, B, alpha);
     }
-
-    // led_strip->sendToStrip(LEDBuf);
 }
 
 void RPiMgr::lightOFStatus(const OFPlayer::Frame& frame) {


### PR DESCRIPTION
### What is this PR for?

LEDPlayer frame less than 2 will led to fatal error, now if good

### What type of PR is it?

[Bug Fix]

### Todos

-   [ ] -   None

### What is the Github issue?

https://github.com/NTUEELightDance/LightDance-RPi/issues/95

### How should this be tested?

### Screenshots (if appropriate)

### Questions:

-   Do the license files need updating? No
-   Are there breaking changes for older versions? No
-   Does this need new documentation? No
