### PR TITLE
RPi-#103. LED_Strip brightness scale

### DIFF
--- a/controller/src/gamma_correction.cpp
+++ b/controller/src/gamma_correction.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #define MAX_BRIGHTNESS 255
+#define LED_STRIP_BRIGHTNESS_SCALE 0.08
 using namespace std;
 
 Color_regulator::Color_regulator(float g) {
@@ -30,11 +31,7 @@ void LEDrgba_to_rgb(vector<char>& LED, const int& index, const char& R, const ch
     float g = float(G) / float(R + G + B);
     float b = float(B) / float(R + G + B);
     // LED format, not error
-    LED[3 * index] = char(g * a * MAX_BRIGHTNESS);
-    LED[3 * index + 1] = char(r * a * MAX_BRIGHTNESS);
-    LED[3 * index + 2] = char(b * a * MAX_BRIGHTNESS);
+    LED[3 * index] = char(g * a * MAX_BRIGHTNESS * LED_STRIP_BRIGHTNESS_SCALE);
+    LED[3 * index + 1] = char(r * a * MAX_BRIGHTNESS * LED_STRIP_BRIGHTNESS_SCALE);
+    LED[3 * index + 2] = char(b * a * MAX_BRIGHTNESS * LED_STRIP_BRIGHTNESS_SCALE);
 }
-// int main(int argc, char *argv[])
-// {
-//   return 0;
-// }


### PR DESCRIPTION
### What is this PR for?

<!-- A few sentences describing the overall goals of the pull request's commits.
-->

LED_Strip is much brighter than Fiber. We need to scale it down.

We tested and set the scale parameter to `0.08`.

### What type of PR is it?

Improvement

### Todos

-   [x] -   add `LED_STRIP_BRIGHTNESS_SCALE`

### What is the Github issue?

Resolve #103 

<!-- * Open an issue on Github
* Put link here, and add [RPi-#issue_number] in PR title, eg. `RPi-#9. PR title`
-->

### How should this be tested?

<!--
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

`ledtest <channel> <color> <alpha>`

### Screenshots (if appropriate)

None

### Questions:

-   Do the license files need updating? No
-   Are there breaking changes for older versions? No
-   Does this need new documentation? No
