### PR TITLE
RPi-#109. Add dark frame if first frame time is not zero

### DIFF
--- a/controller/src/ledplayer.cpp
+++ b/controller/src/ledplayer.cpp
@@ -27,16 +27,20 @@ LEDPlayer::Frame& LEDPlayer::Frame::operator=(const LEDPlayer::Frame& f) {
 }
 
 void LEDPlayer::load(const json& pl) {
-    if (pl.size() == 0){
-        Frame frame;
-        frame.start = 0;
-        frame.fade = false;
-        for (int i = 0; i < len; ++i)
-            frame.status.push_back(LEDStatus(0, 0));
-
-        playList.push_back(frame);
+    Frame darkFrame;
+    darkFrame.start = 0;
+    darkFrame.fade = false;
+    for (int i = 0; i < len; ++i)
+        darkFrame.status.push_back(LEDStatus(0, 0));
+    if (pl.size() == 0) {
+        playList.push_back(darkFrame);
         return;
     }
+    auto it = pl.begin();
+    const size_t firstStartTime = it.value()["start"];
+    if (firstStartTime != 0)
+        playList.push_back(darkFrame);
+
     playList.reserve(pl.size());
     for (auto& f : pl) {
         Frame frame(f["start"], f["fade"], f["status"]);

--- a/controller/src/ofplayer.cpp
+++ b/controller/src/ofplayer.cpp
@@ -18,6 +18,20 @@ void OFPlayer::init(const json& OFparts) {
 }
 
 void OFPlayer::load(const json& pl) {
+    Frame darkFrame;
+    darkFrame.start = 0;
+    darkFrame.fade = false;
+    for (auto it = channelId.begin(); it != channelId.end(); ++it)
+        darkFrame.status.insert(pair<string, OFStatus>(it->first, OFStatus(0, 0)));
+    if (pl.size() == 0) {
+        playList.push_back(darkFrame);
+        return;
+    }
+    auto it = pl.begin();
+    const size_t firstStartTime = it.value()["start"];
+    if (firstStartTime != 0)
+        playList.push_back(darkFrame);
+
     playList.reserve(pl.size());
     for (auto& f : pl) {
         Frame frame(f["start"], f["fade"], f["status"]);


### PR DESCRIPTION
### What is this PR for?

Enable LED.json and OF.json to start not with time 0.

### What type of PR is it?

[Bug Fix]

### Todos

-   [ ] -   Task

### What is the Github issue?

https://github.com/NTUEELightDance/LightDance-RPi/issues/109

### How should this be tested?

### Screenshots (if appropriate)

### Questions:

-   Do the license files need updating? No
-   Are there breaking changes for older versions? No
-   Does this need new documentation? No
